### PR TITLE
49: Google maps API being used for address lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /esd-group-3/nbproject/private/
 /esd-group-3/build/
 /esd-group-3/dist/
+/esd-group-3/src/java/api/api_keys.xml

--- a/esd-group-3/src/java/api/GoogleMaps.java
+++ b/esd-group-3/src/java/api/GoogleMaps.java
@@ -1,0 +1,93 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package api;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.w3c.dom.*;
+import javax.xml.parsers.*;
+import java.io.*;
+/**
+ *
+ * @author morgan
+ */
+public class GoogleMaps {
+    public String lookupAddress(String address) {
+        HttpURLConnection connection = null;
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            
+            StringBuilder xmlStringBuilder = new StringBuilder();
+            Document doc = builder.parse(new java.io.File("src/java/api/api_keys.xml"));
+            
+            Element root = doc.getDocumentElement();
+            
+            String maps_api_key = root.getElementsByTagName("maps").item(0).getTextContent().trim();
+            
+            //Create connection
+            String url_string = "https://maps.googleapis.com/maps/api/place/findplacefromtext/xml?key=" + maps_api_key + "&inputtype=textquery&fields=formatted_address&input=" + URLEncoder.encode(address, "UTF-8"); 
+            URL url = new URL(url_string);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+
+            connection.setUseCaches(false);
+            connection.setDoOutput(true);
+
+            //Send request
+            DataOutputStream wr = new DataOutputStream (
+                connection.getOutputStream());
+            wr.writeBytes(address);
+            wr.close();
+
+            //Get Response  
+            InputStream is = connection.getInputStream();
+            BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                line = line.trim();
+                response.append(line);
+            }
+            rd.close();
+            
+            factory = DocumentBuilderFactory.newInstance();
+            builder = factory.newDocumentBuilder();
+            
+            xmlStringBuilder = new StringBuilder();
+            xmlStringBuilder.append(response);
+            ByteArrayInputStream input = new ByteArrayInputStream(
+               xmlStringBuilder.toString().getBytes("UTF-8")
+            );
+            doc = builder.parse(input);
+            
+            root = doc.getDocumentElement();
+
+            String formatted_address = root.getElementsByTagName("formatted_address").item(0).getTextContent();
+
+            return formatted_address;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+}

--- a/esd-group-3/src/java/api/api_keys.xml.example
+++ b/esd-group-3/src/java/api/api_keys.xml.example
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+
+
+<root>
+    <keys>
+        <google>
+            <maps>
+                GOOGLE_MAPS_API_KEY
+            </maps>
+            <calendar>
+                GOOGLE_CALENDAR_API_KEY
+            </calendar>
+        </google>
+    </keys>
+</root>


### PR DESCRIPTION
Integration of Google Maps API to get a full formatted address from a small part of an address.
`api_keys.xml` needs to be created by copying the `api_keys.xml.example` file and renaming.
Then replace placeholder values with your own API keys.

Usage:
```
GoogleMaps maps = new GoogleMaps();
String address = maps.lookupAddress("10 Downing Street");
```

Closes #49 